### PR TITLE
feat: option for regex escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The **allot** library supports placeholders and regular expressions for paramete
 ## Usage
 
 ```go
-cmd := allot.NewCommand("revert <commits:integer> commits on <project:string> at (stage|prod)")
+cmd := allot.New("revert <commits:integer> commits on <project:string> at (stage|prod)")
 match, err := cmd.Match("revert 12 commits on example at prod")
 
 if (err != nil)
@@ -20,6 +20,10 @@ if (err != nil)
   fmt.Println("Request did not match command.")
 }
 ```
+
+### Regex escaping
+
+If you want to support regex escaping and hence characters like `[]()` in your commands than use `allot.NewWithEscaping()` instead of `allot.New()`.
 
 ## Examples
 

--- a/command_test.go
+++ b/command_test.go
@@ -44,6 +44,30 @@ func TestMatches(t *testing.T) {
 	}
 }
 
+func TestEscapeMatches(t *testing.T) {
+	var data = []struct {
+		command string
+		request string
+		matches bool
+	}{
+		{"[command]", "example", false},
+		{"[command]", "[command]", true},
+		{"command", "command example", false},
+		{"[command] (<lorem>)", "command", false},
+		{"[command] (<lorem>)", "[command] (example)", true},
+		{"[command] (<lorem>)", "[command] (1234)", true},
+		{"[command] (<lorem:integer>)", "[command] (1234)", true},
+	}
+
+	for _, set := range data {
+		cmd := NewWithEscaping(set.command)
+
+		if cmd.Matches(set.request) != set.matches {
+			t.Errorf("Matches() returns unexpected values. Got \"%v\", expected \"%v\"\nExpression: \"%s\" not matching \"%s\"", cmd.Matches(set.request), set.matches, cmd.Expression().String(), set.request)
+		}
+	}
+}
+
 func TestPosition(t *testing.T) {
 	var data = []struct {
 		command  string
@@ -116,7 +140,7 @@ func TestParameters(t *testing.T) {
 
 		for _, param := range set.parameters {
 			if !cmd.Has(param) {
-				t.Errorf("\"%s\" missing parameter.Item \"%s\"", cmd.Text(), param)
+				t.Errorf("\"%s\" missing parameter.Item \"%+v\"", cmd.Text(), param)
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/auhau/allot
+
+go 1.17


### PR DESCRIPTION
This PR adds new constructor for `Command` called `NewWithEscaping` that escapes the Command pattern for regex characters `[],(),...` which allows then passing commands with these characters. I have opted for a new constructor in order not to break the current API and also leave an option for actually accepting valid regex which might be desirable.